### PR TITLE
fix regex for matching errors and warnings

### DIFF
--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -106,7 +106,7 @@ module.exports = function (runner, args, callback) {
         log = log.replace(report[0], '');
 
         log = log.replace(
-          /(^|\n)([\w\/._-]+):(\d+):\s(ERROR|WARNING)\s-\s(.+?)\n([^\n]+)\n(\s*?\^)/g,
+          /(^|\n)([\w\/._-]+):(\d+):\s(ERROR|WARNING)\s-\s(.+?)\n([\s\S]+?)\n(\s*?\^)/g,
           function (match, pre_white, filename, line_no, level, message, code, arrow) {
             var dirname = path.dirname(filename);
             var basename = path.basename(filename);


### PR DESCRIPTION
Currently errors and warnings in log are not matched by regex, because code part of the log can be multiline. This fix ensures it is matched, so errors are red and warnings orange.
