### PR TITLE
throw error when closure compiler fails

### DIFF
--- a/tasks/get-closure-compiler.js
+++ b/tasks/get-closure-compiler.js
@@ -80,6 +80,8 @@ module.exports = function (runner, args, callback) {
     child(command, command_args, function (err, result) {
       if (err) {
         callback(err, null);
+      } else if (result.code == 1) {
+        callback(new Error(result.stdout || result.stderr), null);
       } else {
         callback(null, result.stderr);
       }


### PR DESCRIPTION
When closure compiler runs out of memory, it exits with status code 1 and an error message on stdout. Currently, runner silently continues processing other tasks. It should be terminated immediately.
